### PR TITLE
fix: export Inline primitive

### DIFF
--- a/src/primitives/index.js
+++ b/src/primitives/index.js
@@ -1,5 +1,6 @@
 export { default as Box } from 'reakit/Box';
 export { default as Block } from 'reakit/Block';
+export { default as Inline } from 'reakit/Inline';
 export { default as InlineBlock } from 'reakit/InlineBlock';
 export { default as Flex } from 'reakit/Flex';
 export { default as InlineFlex } from 'reakit/InlineFlex';

--- a/src/primitives/primitives.mdx
+++ b/src/primitives/primitives.mdx
@@ -9,6 +9,7 @@ Fannypack exports Reakit's primitives:
 
 - `<Box>`
 - `<Block>`
+- `<Inline>`
 - `<InlineBlock>`
 - `<Flex>`
 - `<InlineFlex>`
@@ -19,7 +20,7 @@ These primitive components provide an abstraction on top of the `<div>` element 
 You can import them like so:
 
 ```
-import { Box, Block, InlineBlock, Flex, InlineFlex, Grid } from 'fannypack';
+import { Box, Block, Inline, InlineBlock, Flex, InlineFlex, Grid } from 'fannypack';
 ```
 
 See more about primitive components [here](https://reakit.io/components/box).


### PR DESCRIPTION
- export `<Inline>` from 'reakit/Inline 
- added `Inline` to docs