### PR TITLE
Palette docs enhancement

### DIFF
--- a/src/_docs/pages/palette.mdx
+++ b/src/_docs/pages/palette.mdx
@@ -11,6 +11,20 @@ import PaletteColor from '../components/PaletteColor';
 
 The palette is the main color set for Fannypack.
 
+
+## Accessing the palette
+
+Fannypack exports a `palette` utility function which you can use to access palette colors:
+
+```jsx
+import { Text, palette, styled } from 'fannypack';
+
+const PrimaryText = styled(Button)`
+  color: ${palette('primary')};
+`;
+```
+
+
 ## Defaults
 
 <Box marginBottom="major-7">
@@ -178,3 +192,5 @@ The palette is the main color set for Fannypack.
   }
 }
 ```
+
+[Learn more about Styled components](/styling/styled-components)

--- a/src/_docs/pages/palette.mdx
+++ b/src/_docs/pages/palette.mdx
@@ -17,11 +17,21 @@ The palette is the main color set for Fannypack.
 Fannypack exports a `palette` utility function which you can use to access palette colors:
 
 ```jsx
-import { Text, palette, styled } from 'fannypack';
+import { Button, palette, styled } from 'fannypack';
 
-const PrimaryText = styled(Button)`
+const PrimaryButton = styled(Button)`
   color: ${palette('primary')};
 `;
+
+<PrimaryButton> I am a primary button</PrimaryButton>
+```
+
+Any CSS color attribute (e.g. `color`, `border-color`, etc) can take a color from the palette:
+
+```jsx
+import { Text } from 'fannypack';
+
+<Text color="primary">I am a primary text</Text>
 ```
 
 


### PR DESCRIPTION
- Adding `Accessing the palette` example into Palette section.

- PR screenshot reference: [Updated]
 
<img width="926" alt="screen shot 2019-01-17 at 8 37 08 pm" src="https://user-images.githubusercontent.com/41710405/51309093-c4769380-1a97-11e9-827c-e87f40131fb5.png">

