### PR TITLE
Feature: Breadcrumb component

### DIFF
--- a/src/Breadcrumb/Breadcrumb.mdx
+++ b/src/Breadcrumb/Breadcrumb.mdx
@@ -21,9 +21,9 @@ The `<Breadcrumb>` component is used with `<Breadcrumb.Step` to create an access
   
 <Playground>
   <Breadcrumb>
-    <Breadcrumb.Step text="Home" />
-    <Breadcrumb.Step text="Breadcrumb" />
-    <Breadcrumb.Step isCurrent text="Basic Usage" />
+    <Breadcrumb.Step>Home</Breadcrumb.Step>
+    <Breadcrumb.Step>Breadcrumb</Breadcrumb.Step>
+    <Breadcrumb.Step isCurrent>Basic Usage</Breadcrumb.Step>
   </Breadcrumb>
 </Playground>
 

--- a/src/Breadcrumb/Breadcrumb.mdx
+++ b/src/Breadcrumb/Breadcrumb.mdx
@@ -30,8 +30,8 @@ The `<Breadcrumb>` component is used with `<Breadcrumb.Step` to create an access
 <Playground>
   <Breadcrumb separationColor="secondary300">
     <Breadcrumb.Step href="/">Home</Breadcrumb.Step>
-    <Breadcrumb.Step href="/components/breadcrumb">Breadcrumb</Breadcrumb.Step>
-    <Breadcrumb.Step href="components/breadcrumb#basic-usage" isCurrent>Basic Usage</Breadcrumb.Step>
+    <Breadcrumb.Step href="#import">Breadcrumb</Breadcrumb.Step>
+    <Breadcrumb.Step href="#basic-usage" isCurrent>Basic Usage</Breadcrumb.Step>
   </Breadcrumb>
 </Playground>
 

--- a/src/Breadcrumb/Breadcrumb.mdx
+++ b/src/Breadcrumb/Breadcrumb.mdx
@@ -1,0 +1,56 @@
+---
+name: Breadcrumb
+route: /components/breadcrumb
+menu: Components
+---
+
+import { Playground } from 'docz';
+import PropsTable from '../_docs/components/PropsTable';
+import Breadcrumb from './index';
+
+
+# Breadcrumb
+
+## Import
+
+`import { Breadcrumb } from 'fannypack'`
+
+## Basic Usage
+
+The `<Breadcrumb>` component is used with `<Breadcrumb.Step` to create an accessible Breadcrumb.
+  
+<Playground>
+  <Breadcrumb>
+    <Breadcrumb.Step text="Home" />
+    <Breadcrumb.Step text="Breadcrumb" />
+    <Breadcrumb.Step isCurrent text="Basic Usage" />
+  </Breadcrumb>
+</Playground>
+
+## Props
+
+### `<Breadcrumb>`
+<PropsTable component={Breadcrumb} />
+
+### `<Breadcrumb.Step>`
+<PropsTable component={Breadcrumb.Step} />
+
+
+## Theming
+
+### Schema
+
+```jsx
+{
+  base: string | Object,
+  Step: {
+    base: string | Object
+  },
+  List: {
+    base: string | Object
+  },
+  Link: {
+    base: string | Object
+  }
+}
+```

--- a/src/Breadcrumb/Breadcrumb.mdx
+++ b/src/Breadcrumb/Breadcrumb.mdx
@@ -59,6 +59,9 @@ The `<Breadcrumb>` component is used with `<Breadcrumb.Step` to create an access
   },
   Link: {
     base: string | Object
+  },
+  Span: {
+    base: string | Object
   }
 }
 ```

--- a/src/Breadcrumb/Breadcrumb.mdx
+++ b/src/Breadcrumb/Breadcrumb.mdx
@@ -27,6 +27,14 @@ The `<Breadcrumb>` component is used with `<Breadcrumb.Step` to create an access
   </Breadcrumb>
 </Playground>
 
+<Playground>
+  <Breadcrumb separationColor="secondary300">
+    <Breadcrumb.Step href="/">Home</Breadcrumb.Step>
+    <Breadcrumb.Step href="/components/breadcrumb">Breadcrumb</Breadcrumb.Step>
+    <Breadcrumb.Step href="components/breadcrumb#basic-usage" isCurrent>Basic Usage</Breadcrumb.Step>
+  </Breadcrumb>
+</Playground>
+
 ## Props
 
 ### `<Breadcrumb>`

--- a/src/Breadcrumb/Breadcrumb.tsx
+++ b/src/Breadcrumb/Breadcrumb.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { Breadcrumb as _Breadcrumb, BreadcrumbList as _BreadcrumbList } from './styled';
-import BreadcrumbStep, { BreadcrumbStepProps } from './BreadcrumbStep';
+import BreadcrumbStep, { LocalBreadcrumbStepProps } from './BreadcrumbStep';
 
 export type LocalBreadcrumbProps = {
   children: React.ReactNode;
@@ -14,7 +14,7 @@ export type BreadcrumbProps = {
 };
 
 export type BreadcrumbComponents = {
-  Step: React.FunctionComponent<BreadcrumbStepProps>;
+  Step: React.FunctionComponent<LocalBreadcrumbStepProps>;
 };
 
 export const Breadcrumb: React.FunctionComponent<LocalBreadcrumbProps> & BreadcrumbComponents = ({

--- a/src/Breadcrumb/Breadcrumb.tsx
+++ b/src/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,46 @@
+/* eslint react/prop-types: 0 */
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import { Breadcrumb as _Breadcrumb, BreadcrumbList as _BreadcrumbList } from './styled';
+import BreadcrumbStep, { BreadcrumbStepProps } from './BreadcrumbStep';
+
+export type LocalBreadcrumbProps = {
+  children: React.ReactNode;
+  separationColor?: string;
+};
+
+export type BreadcrumbProps = {
+  separationColor?: string;
+};
+
+export type BreadcrumbComponents = {
+  Step: React.FunctionComponent<BreadcrumbStepProps>;
+};
+
+export const Breadcrumb: React.FunctionComponent<LocalBreadcrumbProps> & BreadcrumbComponents = ({
+  children,
+  separationColor
+}) => {
+  return (
+    <_Breadcrumb a11yTitle="Breadcrumb" separationColor={separationColor}>
+      <_BreadcrumbList isOrdered isHorizontal>
+        {children}
+      </_BreadcrumbList>
+    </_Breadcrumb>
+  );
+};
+
+Breadcrumb.Step = BreadcrumbStep;
+
+Breadcrumb.propTypes = {
+  children: PropTypes.node.isRequired,
+  separationColor: PropTypes.string
+};
+
+Breadcrumb.defaultProps = {
+  separationColor: ''
+};
+
+// @ts-ignore
+const C: React.FunctionComponent<LocalBreadcrumbProps> & BreadcrumbComponents = Breadcrumb;
+export default C;

--- a/src/Breadcrumb/BreadcrumbStep.tsx
+++ b/src/Breadcrumb/BreadcrumbStep.tsx
@@ -2,7 +2,11 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 
-import { BreadcrumbStep as _BreadcrumbStep, BreadcrumbLink as _BreadcrumbLink } from './styled';
+import {
+  BreadcrumbStep as _BreadcrumbStep,
+  BreadcrumbLink as _BreadcrumbLink,
+  BreadcrumbSpan as _BreadcrumbSpan
+} from './styled';
 
 export type LocalBreadcrumbStepProps = {
   children: React.ReactNode;
@@ -13,9 +17,15 @@ export type LocalBreadcrumbStepProps = {
 
 const BreadcrumbStep: React.FunctionComponent<LocalBreadcrumbStepProps> = ({ children, color, href, isCurrent }) => (
   <_BreadcrumbStep>
-    <_BreadcrumbLink aria-current={isCurrent ? 'page' : undefined} color={color} href={href}>
-      {children}
-    </_BreadcrumbLink>
+    {href ? (
+      <_BreadcrumbLink aria-current={isCurrent ? 'page' : undefined} color={color} href={href}>
+        {children}
+      </_BreadcrumbLink>
+    ) : (
+      <_BreadcrumbSpan aria-current={isCurrent ? 'page' : undefined} color={color}>
+        {children}
+      </_BreadcrumbSpan>
+    )}
   </_BreadcrumbStep>
 );
 
@@ -27,7 +37,7 @@ BreadcrumbStep.propTypes = {
 };
 
 BreadcrumbStep.defaultProps = {
-  color: '',
+  color: undefined,
   href: undefined,
   isCurrent: undefined
 };

--- a/src/Breadcrumb/BreadcrumbStep.tsx
+++ b/src/Breadcrumb/BreadcrumbStep.tsx
@@ -5,17 +5,15 @@ import * as PropTypes from 'prop-types';
 import { BreadcrumbStep as _BreadcrumbStep, BreadcrumbLink as _BreadcrumbLink } from './styled';
 
 export type LocalBreadcrumbStepProps = {
-  color: string;
+  color?: string;
   href: string;
-  isCurrent: boolean;
+  isCurrent?: boolean;
   text: string;
 };
 
-export type BreadcrumbStepProps = LocalBreadcrumbStepProps;
-
 const BreadcrumbStep: React.FunctionComponent<LocalBreadcrumbStepProps> = ({ color, href, isCurrent, text }) => (
   <_BreadcrumbStep>
-    <_BreadcrumbLink aria-current={isCurrent ? 'page' : undefined} href={href} color={color}>
+    <_BreadcrumbLink aria-current={isCurrent ? 'page' : undefined} color={color} href={href}>
       {text}
     </_BreadcrumbLink>
   </_BreadcrumbStep>
@@ -23,16 +21,15 @@ const BreadcrumbStep: React.FunctionComponent<LocalBreadcrumbStepProps> = ({ col
 
 BreadcrumbStep.propTypes = {
   color: PropTypes.string,
-  href: PropTypes.string.isRequired,
   isCurrent: PropTypes.bool,
-  text: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired
 };
 
 BreadcrumbStep.defaultProps = {
   color: '',
-  isCurrent: false,
+  isCurrent: false
 };
 
 // @ts-ignore
-const C: React.FunctionComponent<BreadcrumbStepProps> = BreadcrumbStep;
+const C: React.FunctionComponent<LocalBreadcrumbStepProps> = BreadcrumbStep;
 export default C;

--- a/src/Breadcrumb/BreadcrumbStep.tsx
+++ b/src/Breadcrumb/BreadcrumbStep.tsx
@@ -5,29 +5,31 @@ import * as PropTypes from 'prop-types';
 import { BreadcrumbStep as _BreadcrumbStep, BreadcrumbLink as _BreadcrumbLink } from './styled';
 
 export type LocalBreadcrumbStepProps = {
+  children: React.ReactNode;
   color?: string;
-  href: string;
+  href?: string;
   isCurrent?: boolean;
-  text: string;
 };
 
-const BreadcrumbStep: React.FunctionComponent<LocalBreadcrumbStepProps> = ({ color, href, isCurrent, text }) => (
+const BreadcrumbStep: React.FunctionComponent<LocalBreadcrumbStepProps> = ({ children, color, href, isCurrent }) => (
   <_BreadcrumbStep>
     <_BreadcrumbLink aria-current={isCurrent ? 'page' : undefined} color={color} href={href}>
-      {text}
+      {children}
     </_BreadcrumbLink>
   </_BreadcrumbStep>
 );
 
 BreadcrumbStep.propTypes = {
+  children: PropTypes.node.isRequired,
   color: PropTypes.string,
-  isCurrent: PropTypes.bool,
-  text: PropTypes.string.isRequired
+  href: PropTypes.string,
+  isCurrent: PropTypes.bool
 };
 
 BreadcrumbStep.defaultProps = {
   color: '',
-  isCurrent: false
+  href: undefined,
+  isCurrent: undefined
 };
 
 // @ts-ignore

--- a/src/Breadcrumb/BreadcrumbStep.tsx
+++ b/src/Breadcrumb/BreadcrumbStep.tsx
@@ -1,0 +1,38 @@
+/* eslint react/prop-types: 0 */
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+
+import { BreadcrumbStep as _BreadcrumbStep, BreadcrumbLink as _BreadcrumbLink } from './styled';
+
+export type LocalBreadcrumbStepProps = {
+  color: string;
+  href: string;
+  isCurrent: boolean;
+  text: string;
+};
+
+export type BreadcrumbStepProps = LocalBreadcrumbStepProps;
+
+const BreadcrumbStep: React.FunctionComponent<LocalBreadcrumbStepProps> = ({ color, href, isCurrent, text }) => (
+  <_BreadcrumbStep>
+    <_BreadcrumbLink aria-current={isCurrent ? 'page' : undefined} href={href} color={color}>
+      {text}
+    </_BreadcrumbLink>
+  </_BreadcrumbStep>
+);
+
+BreadcrumbStep.propTypes = {
+  color: PropTypes.string,
+  href: PropTypes.string.isRequired,
+  isCurrent: PropTypes.bool,
+  text: PropTypes.string.isRequired,
+};
+
+BreadcrumbStep.defaultProps = {
+  color: '',
+  isCurrent: false,
+};
+
+// @ts-ignore
+const C: React.FunctionComponent<BreadcrumbStepProps> = BreadcrumbStep;
+export default C;

--- a/src/Breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/src/Breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -6,9 +6,9 @@ describe('Breadcrumb', () => {
   it('renders correctly', () => {
     const { container } = render(
       <Breadcrumb>
-        <Breadcrumb.Step text="Home" />
-        <Breadcrumb.Step text="Breadcrumb" />
-        <Breadcrumb.Step isCurrent text="Basic Usage" />
+        <Breadcrumb.Step>Home</Breadcrumb.Step>
+        <Breadcrumb.Step>Breadcrumb</Breadcrumb.Step>
+        <Breadcrumb.Step isCurrent>Basic Usage</Breadcrumb.Step>
       </Breadcrumb>
     );
     expect(container.firstChild).toMatchSnapshot();
@@ -17,10 +17,10 @@ describe('Breadcrumb', () => {
   describe('with custom separationColor', () => {
     it('renders correctly', () => {
       const { container } = render(
-        <Breadcrumb separationColor="success">
-          <Breadcrumb.Step text="Home" />
-          <Breadcrumb.Step text="Breadcrumb" />
-          <Breadcrumb.Step isCurrent text="Basic Usage" />
+        <Breadcrumb>
+          <Breadcrumb.Step>Home</Breadcrumb.Step>
+          <Breadcrumb.Step>Breadcrumb</Breadcrumb.Step>
+          <Breadcrumb.Step isCurrent>Basic Usage</Breadcrumb.Step>
         </Breadcrumb>
       );
       expect(container.firstChild).toMatchSnapshot();

--- a/src/Breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/src/Breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -26,4 +26,19 @@ describe('Breadcrumb', () => {
       expect(container.firstChild).toMatchSnapshot();
     });
   });
+
+  describe('with link', () => {
+    it('renders correctly', () => {
+      const { container } = render(
+        <Breadcrumb>
+          <Breadcrumb.Step href="/home">Home</Breadcrumb.Step>
+          <Breadcrumb.Step href="/breadcrumb">Breadcrumb</Breadcrumb.Step>
+          <Breadcrumb.Step href="/usage" isCurrent>
+            Basic Usage
+          </Breadcrumb.Step>
+        </Breadcrumb>
+      );
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
 });

--- a/src/Breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/src/Breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import render from '../../_utils/tests/render';
+import Breadcrumb from '../Breadcrumb';
+
+describe('Breadcrumb', () => {
+  it('renders correctly', () => {
+    const { container } = render(
+      <Breadcrumb>
+        <Breadcrumb.Step text="Home" />
+        <Breadcrumb.Step text="Breadcrumb" />
+        <Breadcrumb.Step isCurrent text="Basic Usage" />
+      </Breadcrumb>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  describe('with custom separationColor', () => {
+    it('renders correctly', () => {
+      const { container } = render(
+        <Breadcrumb separationColor="success">
+        <Breadcrumb.Step text="Home" />
+        <Breadcrumb.Step text="Breadcrumb" />
+        <Breadcrumb.Step isCurrent text="Basic Usage" />
+        </Breadcrumb>
+      );
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+});

--- a/src/Breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/src/Breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -18,9 +18,9 @@ describe('Breadcrumb', () => {
     it('renders correctly', () => {
       const { container } = render(
         <Breadcrumb separationColor="success">
-        <Breadcrumb.Step text="Home" />
-        <Breadcrumb.Step text="Breadcrumb" />
-        <Breadcrumb.Step isCurrent text="Basic Usage" />
+          <Breadcrumb.Step text="Home" />
+          <Breadcrumb.Step text="Breadcrumb" />
+          <Breadcrumb.Step isCurrent text="Basic Usage" />
         </Breadcrumb>
       );
       expect(container.firstChild).toMatchSnapshot();

--- a/src/Breadcrumb/index.ts
+++ b/src/Breadcrumb/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Breadcrumb';
+export { default as Breadcrumb } from './Breadcrumb';

--- a/src/Breadcrumb/styled.ts
+++ b/src/Breadcrumb/styled.ts
@@ -4,6 +4,7 @@ import { List } from '../List';
 import { Navigation } from '../Navigation';
 import { Link } from '../Link';
 import { BreadcrumbProps } from './Breadcrumb';
+import { Inline } from '../primitives';
 
 export const Breadcrumb = styled(Navigation)<BreadcrumbProps>`
   & li + li::before {
@@ -41,6 +42,12 @@ export const BreadcrumbList = styled(List)`
 export const BreadcrumbStep = styled(List.Item)`
   & {
     ${theme('fannypack.Breadcrumb.Step.base')};
+  }
+`;
+
+export const BreadcrumbSpan = styled(Inline)`
+  & {
+    ${theme('fannypack.Breadcrumb.Span.base')};
   }
 `;
 

--- a/src/Breadcrumb/styled.ts
+++ b/src/Breadcrumb/styled.ts
@@ -1,0 +1,51 @@
+import { theme, palette } from 'styled-tools';
+import styled, { space } from '../styled';
+import { List } from '../List';
+import { Navigation } from '../Navigation';
+import { Link } from '../Link';
+import { BreadcrumbProps } from './Breadcrumb';
+
+export const Breadcrumb = styled(Navigation)<BreadcrumbProps>`
+  & li + li::before {
+    border-right-color: ${props => palette(props.separationColor || 'text100', props.separationColor)};
+    border-right-style: solid;
+    border-right-width: ${space(0.5)}rem;
+    content: '';
+    display: inline-block;
+    height: 0.8rem;
+    margin: 0 ${space(4)}rem;
+    msrgin-right: 0;
+    transform: rotate(15deg);
+  }
+
+  & [aria-current='page'] {
+    font-weight: ${theme('fannypack.fontWeights.bold')};
+    text-decoration: none;
+  }
+
+  & {
+    ${theme('fannypack.Breadcrumb.base')};
+  }
+`;
+
+export const BreadcrumbList = styled(List)`
+  & li {
+    margin-right: 0;
+  }
+
+  & {
+    ${theme('fannypack.Breadcrumb.List.base')};
+  }
+`;
+
+export const BreadcrumbStep = styled(List.Item)`
+  & {
+    ${theme('fannypack.Breadcrumb.Step.base')};
+  }
+`;
+
+export const BreadcrumbLink = styled(Link)`
+  & {
+    ${theme('fannypack.Breadcrumb.Link.base')};
+  }
+`;

--- a/src/Breadcrumb/styled.ts
+++ b/src/Breadcrumb/styled.ts
@@ -19,7 +19,7 @@ export const Breadcrumb = styled(Navigation)<BreadcrumbProps>`
   }
 
   & [aria-current='page'] {
-    font-weight: ${theme('fannypack.fontWeights.bold')};
+    font-weight: ${theme('fannypack.fontWeights.semibold')};
     text-decoration: none;
   }
 

--- a/src/_docs/pages/stylingtheming/theming.mdx
+++ b/src/_docs/pages/stylingtheming/theming.mdx
@@ -147,6 +147,7 @@ const App = () => (
 - [AvatarThemeConfig] (/components/avatar#theming)
 - [BackdropThemeConfig](/utils/backdrop#theming)
 - [BlockquoteThemeConfig](/typography/blockquote#theming)
+- [BreadcrumbThemeConfig](/components/breadcrumb#theming)
 - [ButtonThemeConfig](/components/button#theming)
 - [CalloutThemeConfig](/components/callout#theming)
 - [CalloutOverlayThemeConfig](/components/calloutoverlay#theming)
@@ -220,6 +221,3 @@ The layout theme config is used to manage breakpoints & spacing (like paddings &
   majorUnit: 8
 }
 ```
-
-
-

--- a/src/_docs/utils/components.ts
+++ b/src/_docs/utils/components.ts
@@ -78,8 +78,8 @@ export const componentList: Array<ComponentDetails> = [
   {
     name: 'Breadcrumb',
     type: 'component',
-    status: 'pending',
-    docsPath: 'https://github.com/fannypackui/fannypack/issues/1'
+    status: 'complete',
+    docsPath: 'components/breadcrumb'
   },
   {
     name: 'Button',

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export { Avatar } from './Avatar';
 export { Backdrop } from './Backdrop';
 export { Blockquote } from './Blockquote';
 export { ActionButtons, Button } from './Button';
+export { Breadcrumb } from './Breadcrumb';
 export { Callout } from './Callout';
 export { CalloutOverlay } from './CalloutOverlay';
 export { Card, CardCard, CardContent, CardFooter, CardHeader, CardTitle } from './Card';

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -34,6 +34,9 @@ export type BreadcrumbThemeConfig = {
   Link?: {
     base?: Stylesheet;
   };
+  Span?: {
+    base?: Stylesheet;
+  };
 };
 export type ButtonThemeConfig = {
   base?: Stylesheet;

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -23,6 +23,18 @@ export type BackdropThemeConfig = {
 export type BlockquoteThemeConfig = {
   base?: Stylesheet;
 };
+export type BreadcrumbThemeConfig = {
+  base?: Stylesheet;
+  Step?: {
+    base?: Stylesheet;
+  };
+  List?: {
+    base?: Stylesheet;
+  };
+  Link?: {
+    base?: Stylesheet;
+  };
+};
 export type ButtonThemeConfig = {
   base?: Stylesheet;
   disabled?: Stylesheet;
@@ -625,6 +637,7 @@ export type ThemeConfig = {
   Avatar?: AvatarThemeConfig;
   Backdrop?: BackdropThemeConfig;
   Blockquote?: BlockquoteThemeConfig;
+  Breadcrumb?: BreadcrumbThemeConfig;
   Button?: ButtonThemeConfig;
   Checkbox?: CheckboxThemeConfig;
   Callout?: CalloutThemeConfig;


### PR DESCRIPTION
ref #40 

name: Breadcrumb
route: /components/breadcrumb
menu: Components

I followed this a11y guide:
https://www.w3.org/TR/wai-aria-practices/examples/breadcrumb/index.html

Screenshot reference: (updated)
- docs now show an example  with and without `href`

<img width="888" alt="screen shot 2019-02-04 at 2 43 33 pm" src="https://user-images.githubusercontent.com/41710405/52189779-ca89b400-288e-11e9-9aea-915a78a9933f.png">


