### PR TITLE
(fix) Missing `em` unit for font-size.

### DIFF
--- a/src/_docs/pages/stylingtheming/fonts.mdx
+++ b/src/_docs/pages/stylingtheming/fonts.mdx
@@ -105,7 +105,7 @@ You can also access the font sizes in Styled Components through the Fannypack Th
 import { Text, theme, styled } from 'fannypack';
 
 const LargeText = styled(Text)`
-  font-size: ${theme('fannypack.fontSizes.700')};
+  font-size: ${theme('fannypack.fontSizes.700')}em;
 `;
 ```
 


### PR DESCRIPTION
Without font-size unit it seems to not change the font size.

In the fannypack code base either `em` or `rem` are used (see: `styled.ts` files).