### PR TITLE
WIP: (feature) Allow MenuGroup title prop to be a ReactElement.

### DIFF
--- a/src/Menu/MenuGroup.tsx
+++ b/src/Menu/MenuGroup.tsx
@@ -7,6 +7,7 @@ import { MenuGroup as _MenuGroup, MenuGroupTitle } from './styled';
 
 export type LocalMenuGroupProps = {
   children: React.ReactNode;
+  title?: string | React.ReactElement<any>;
 };
 export type MenuGroupProps = Omit<Omit<ReakitBoxProps, 'as'>, 'elementRef'> & LocalMenuGroupProps;
 
@@ -19,7 +20,7 @@ export const MenuGroup: React.FunctionComponent<MenuGroupProps> = ({ children, t
 
 MenuGroup.propTypes = {
   children: PropTypes.node.isRequired,
-  title: PropTypes.string
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
 };
 MenuGroup.defaultProps = {};
 


### PR DESCRIPTION
**work in progress. do not merge**

This lets the TypeScript compiler output an error.

~~~
Type '{ children: Validator<string | number | boolean | {} | ReactElementLike | ReactNodeArray>; title: Requireable<string | ReactElementLike>; }' is not assignable to type 'WeakValidationMap<MenuGroupProps>'.
  Types of property 'title' are incompatible.
    Type 'Requireable<string | ReactElementLike>' is not assignable to type 'Validator<string | (string & ReactElement<any>) | null | undefined>'.ts(2322)
~~~

Fixes #48.
