### PR TITLE
fix: a11y updates on CardTitle

### DIFF
--- a/packages/fannypack/src/Card/CardTitle.tsx
+++ b/packages/fannypack/src/Card/CardTitle.tsx
@@ -11,9 +11,7 @@ export type LocalCardTitleProps = {
 export type CardTitleProps = LocalCardTitleProps & ReakitHeadingProps;
 
 const CardTitle: React.FunctionComponent<LocalCardTitleProps> = ({ children, ...props }) => (
-  <_CardTitle use="h5" isSubHeading {...props}>
-    {children}
-  </_CardTitle>
+  <_CardTitle {...props}>{children}</_CardTitle>
 );
 
 CardTitle.propTypes = {

--- a/packages/fannypack/src/Card/styled.ts
+++ b/packages/fannypack/src/Card/styled.ts
@@ -1,6 +1,6 @@
 import { theme } from 'styled-tools';
 
-import styled, { css, space } from '../styled';
+import styled, { space } from '../styled';
 import { Box } from '../primitives';
 import { CardCardProps } from './CardCard';
 import { CardContentProps } from './CardContent';
@@ -9,7 +9,7 @@ import { CardHeaderProps } from './CardHeader';
 import { CardTitleProps } from './CardTitle';
 import Pane from '../Pane';
 // @ts-ignore
-import Heading from '../Heading';
+import Text from '../Text';
 
 export default styled(Pane)<CardCardProps>`
   padding: ${space(6, 'minor')}rem;
@@ -45,10 +45,9 @@ export const CardFooter = styled(Box)<CardFooterProps>`
     ${theme('fannypack.Card.Footer.base')};
   }
 `;
-export const CardTitle = styled(Heading)<CardTitleProps>`
-  && {
-    margin-bottom: 0px;
-  }
+export const CardTitle = styled(Text)<CardTitleProps>`
+  font-weight: ${theme('fannypack.fontWeights.semibold')};
+  font-size: ${theme('fannypack.fontSizes.300')}rem;
 
   & {
     ${theme('fannypack.Card.Title.base')};

--- a/packages/website/pages/components/card.mdx
+++ b/packages/website/pages/components/card.mdx
@@ -95,7 +95,7 @@ The `<Card>` component is made up of a compound of components (such as: `<Card.C
 ```.jsx
 <Card.Card a11yDescriptionId="description" a11yTitleId="title">
   <Card.Header>
-    <Card.Title id="title">This is a title</Card.Title>
+    <Card.Title id="title" use="h4">This is a title that uses heading level 4</Card.Title>
   </Card.Header>
   <Card.Content id="description">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse diam ipsum, cursus id placerat congue,


### PR DESCRIPTION
this enhancement helps to avoid a fixed heading level within `Card.Title` component so that a fannypack consumer could render a heading according to their Headind's hierarchy, e.g.:
e.g.:

```
<Card.Card a11yDescriptionId="description" a11yTitleId="title">
  <Card.Header>
    <Card.Title id="title" use="h4">This is a title that uses heading level 4</Card.Title>
  </Card.Header>
```

cc: @jxom 