### PR TITLE
Fix/select svg icon with pointer events none

### DIFF
--- a/packages/fannypack/src/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/fannypack/src/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -53,6 +53,7 @@ exports[`renders correctly for a basic select 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c2 {
@@ -179,6 +180,7 @@ exports[`renders correctly for a disabled select 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c2 {
@@ -313,6 +315,7 @@ exports[`renders correctly for a full width select 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c2 {
@@ -444,6 +447,7 @@ exports[`renders correctly for a select with a default value 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c2 {
@@ -575,6 +579,7 @@ exports[`renders correctly for a select with a placeholder 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c6[disabled] + .c4 {
@@ -711,6 +716,7 @@ exports[`sizes renders correctly for a select with size large 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c6[disabled] + .c4 {
@@ -879,6 +885,7 @@ exports[`sizes renders correctly for a select with size medium 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c6[disabled] + .c4 {
@@ -1038,6 +1045,7 @@ exports[`sizes renders correctly for a select with size small 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c6[disabled] + .c4 {
@@ -1187,6 +1195,7 @@ exports[`states renders correctly for a select with state danger 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c6[disabled] + .c4 {
@@ -1353,6 +1362,7 @@ exports[`states renders correctly for a select with state primary 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c6[disabled] + .c4 {
@@ -1531,6 +1541,7 @@ exports[`states renders correctly for a select with state success 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c6[disabled] + .c4 {
@@ -1701,6 +1712,7 @@ exports[`states renders correctly for a select with state warning 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c6[disabled] + .c4 {

--- a/packages/fannypack/src/Select/__tests__/__snapshots__/SelectField.test.tsx.snap
+++ b/packages/fannypack/src/Select/__tests__/__snapshots__/SelectField.test.tsx.snap
@@ -99,6 +99,7 @@ exports[`renders correctly for a basic select 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c8 {
@@ -304,6 +305,7 @@ exports[`renders correctly for a disabled select 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c8 {
@@ -517,6 +519,7 @@ exports[`renders correctly for a full width select 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c8 {
@@ -727,6 +730,7 @@ exports[`renders correctly for a required field 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c8 {
@@ -979,6 +983,7 @@ exports[`renders correctly for a select with a default value 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c8 {
@@ -1189,6 +1194,7 @@ exports[`renders correctly for a select with a placeholder 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c12[disabled] + .c10 {
@@ -1460,6 +1466,7 @@ exports[`renders correctly for addon component (after) 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c10 {
@@ -1776,6 +1783,7 @@ exports[`renders correctly for addon component (before) 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c10 {
@@ -2092,6 +2100,7 @@ exports[`renders correctly for addon component (vertical) 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c10 {
@@ -2352,6 +2361,7 @@ exports[`renders correctly for an input field with a description 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c10 {
@@ -2671,6 +2681,7 @@ exports[`renders correctly for an input field with a hint 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c8 {
@@ -2991,6 +3002,7 @@ exports[`renders correctly for an optional input field 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c10 {
@@ -3313,6 +3325,7 @@ exports[`sizes renders correctly for a select with size large 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c12[disabled] + .c10 {
@@ -3560,6 +3573,7 @@ exports[`sizes renders correctly for a select with size medium 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c12[disabled] + .c10 {
@@ -3798,6 +3812,7 @@ exports[`sizes renders correctly for a select with size small 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c12[disabled] + .c10 {
@@ -4026,6 +4041,7 @@ exports[`states renders correctly for a select with state danger 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c12[disabled] + .c10 {
@@ -4271,6 +4287,7 @@ exports[`states renders correctly for a select with state primary 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c12[disabled] + .c10 {
@@ -4528,6 +4545,7 @@ exports[`states renders correctly for a select with state success 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c12[disabled] + .c10 {
@@ -4777,6 +4795,7 @@ exports[`states renders correctly for a select with state warning 1`] = `
   -webkit-transform: translateY(50%);
   -ms-transform: translateY(50%);
   transform: translateY(50%);
+  pointer-events: none;
 }
 
 .c12[disabled] + .c10 {

--- a/packages/fannypack/src/Select/styled.ts
+++ b/packages/fannypack/src/Select/styled.ts
@@ -18,6 +18,7 @@ export const Icon = styled.svg`
   z-index: 1;
   fill: ${palette('text')};
   transform: translateY(50%);
+  pointer-events: none;
 `;
 
 export const LoadingSpinner = styled(Spinner)`


### PR DESCRIPTION
## What does this PR resolve?
- an issue with pointer events on SVG icon in Select component in Desktop browsers.

## Fixes
- the select option will now be displayed if you try to click over the SVG arrow.

## Screenshot

<img width="199" alt="Screen Shot 2019-05-19 at 2 28 51 pm" src="https://user-images.githubusercontent.com/41710405/57977753-baaf6d80-7a42-11e9-836e-0208c47064a1.png">

## Testing

- yarn lint && yarn jest
- go to http://localhost:3000/form/select
- click on any select SVG arrow.
- it should open the select option list.

## References
> The pointer-events CSS property sets under what circumstances (if any) a particular graphic element can become the target of pointer events.
Ref MDN docs. https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events

