### PR TITLE
Bugfix: Fix the spacing between breadcrumb steps

### DIFF
--- a/packages/fannypack/src/Breadcrumb/styled.ts
+++ b/packages/fannypack/src/Breadcrumb/styled.ts
@@ -14,8 +14,7 @@ export const Breadcrumb = styled(Navigation)<BreadcrumbProps>`
     content: '';
     display: inline-block;
     height: 0.8rem;
-    margin: 0 ${space(4)}rem;
-    margin-right: 0;
+    margin: 0 ${space(2)}rem;
     transform: rotate(15deg);
   }
 


### PR DESCRIPTION
# What does this resolve?

This PR fixes the spacing between breadcrumb steps so the separator sits between the two items. This has been erking me for a while, and since it's Hacktoberfest - might as well do some contributions.

Thanks @jxom!

# Screenshots

*Before*

<img width="728" alt="Screen Shot 2019-10-05 at 11 02 10 am" src="https://user-images.githubusercontent.com/1747517/66247551-1879f300-e761-11e9-9bb9-1cc64d169864.png">

*After*
<img width="722" alt="Screen Shot 2019-10-05 at 11 05 47 am" src="https://user-images.githubusercontent.com/1747517/66247553-1d3ea700-e761-11e9-929f-8954b697196c.png">
