### PR TITLE
fix: extend reakit box props with visibility props

### DIFF
--- a/packages/fannypack/src/Alert/Alert.tsx
+++ b/packages/fannypack/src/Alert/Alert.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 // @ts-ignore
 import _omit from 'lodash/omit';
 

--- a/packages/fannypack/src/Backdrop/Backdrop.tsx
+++ b/packages/fannypack/src/Backdrop/Backdrop.tsx
@@ -4,7 +4,6 @@ import { BackdropProps as ReakitBackdropProps } from 'reakit/ts/Backdrop/Backdro
 
 import _Backdrop from './styled';
 import {
-  Omit,
   AnimateProps,
   animatePropTypes,
   animateDefaultProps,

--- a/packages/fannypack/src/Card/CardContent.tsx
+++ b/packages/fannypack/src/Card/CardContent.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 
 import { CardContent as _CardContent } from './styled';
 

--- a/packages/fannypack/src/Card/CardFooter.tsx
+++ b/packages/fannypack/src/Card/CardFooter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 
 import { CardFooter as _CardFooter } from './styled';
 

--- a/packages/fannypack/src/Card/CardHeader.tsx
+++ b/packages/fannypack/src/Card/CardHeader.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 
 import { CardHeader as _CardHeader } from './styled';
 

--- a/packages/fannypack/src/Code/HighlightedCode.tsx
+++ b/packages/fannypack/src/Code/HighlightedCode.tsx
@@ -11,7 +11,7 @@ import javascript from 'react-syntax-highlighter/languages/prism/javascript';
 import jsx from 'react-syntax-highlighter/languages/prism/jsx';
 // @ts-ignore
 import json from 'react-syntax-highlighter/languages/prism/json';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 // @ts-ignore
 import _get from 'lodash/get';
 

--- a/packages/fannypack/src/Column/Column.tsx
+++ b/packages/fannypack/src/Column/Column.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 
 import { ColumnSpread, ColumnSpreadOffset, columnSpreadPropType, columnSpreadOffsetPropType } from '../types';
 import ColumnsContext, { ColumnsContextProps } from '../Columns/ColumnsContext';

--- a/packages/fannypack/src/Columns/Columns.tsx
+++ b/packages/fannypack/src/Columns/Columns.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 
 import ColumnsContext from './ColumnsContext';
 import _Columns from './styled';

--- a/packages/fannypack/src/Container/Container.tsx
+++ b/packages/fannypack/src/Container/Container.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 
 import { Breakpoint, breakpointPropType } from '../types';
 import _Container from './styled';

--- a/packages/fannypack/src/Dialog/DialogContent.tsx
+++ b/packages/fannypack/src/Dialog/DialogContent.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 
 import { DialogContent as _DialogContent } from './styled';
 

--- a/packages/fannypack/src/Dialog/DialogFooter.tsx
+++ b/packages/fannypack/src/Dialog/DialogFooter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 
 import { DialogFooter as _DialogFooter } from './styled';
 

--- a/packages/fannypack/src/Dialog/DialogHeader.tsx
+++ b/packages/fannypack/src/Dialog/DialogHeader.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 
 import { DialogHeader as _DialogHeader } from './styled';
 

--- a/packages/fannypack/src/Dialog/DialogTitle.tsx
+++ b/packages/fannypack/src/Dialog/DialogTitle.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 
 import { DialogTitle as _DialogTitle } from './styled';
 

--- a/packages/fannypack/src/Icon/Icon.tsx
+++ b/packages/fannypack/src/Icon/Icon.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 // @ts-ignore
 import propTypeUtils from 'airbnb-prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 // @ts-ignore
 import _get from 'lodash/get';
 

--- a/packages/fannypack/src/List/ListItem.tsx
+++ b/packages/fannypack/src/List/ListItem.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 
 import { ListItem as _ListItem } from './styled';
 

--- a/packages/fannypack/src/Menu/MenuTrigger.tsx
+++ b/packages/fannypack/src/Menu/MenuTrigger.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 
 import { Box } from '../primitives';
 import { withMenuContext, MenuContextState } from './MenuContext';

--- a/packages/fannypack/src/Pane/Pane.tsx
+++ b/packages/fannypack/src/Pane/Pane.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 import { Omit } from '../types';
 
 import _Pane from './styled';

--- a/packages/fannypack/src/ProgressBar/ProgressBar.tsx
+++ b/packages/fannypack/src/ProgressBar/ProgressBar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 // @ts-ignore
 import _get from 'lodash/get';
 

--- a/packages/fannypack/src/Radio/RadioGroup.tsx
+++ b/packages/fannypack/src/Radio/RadioGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 
 import { formikField, reduxFormField } from '../adaptors/fields';
 import { RadioGroup as _RadioGroup } from './styled';

--- a/packages/fannypack/src/Rating/Rating.tsx
+++ b/packages/fannypack/src/Rating/Rating.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 // @ts-ignore
 import times from 'lodash/times';
 

--- a/packages/fannypack/src/Rating/RatingStar.tsx
+++ b/packages/fannypack/src/Rating/RatingStar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { BoxProps as ReakitBoxProps } from 'reakit/ts';
+import { ReakitBoxProps } from '../types';
 
 import { Omit, Size } from '../types';
 import { RatingStar as _RatingStar } from './styled';

--- a/packages/fannypack/src/types/props.ts
+++ b/packages/fannypack/src/types/props.ts
@@ -1,4 +1,5 @@
 import * as PropTypes from 'prop-types';
+import { BoxProps } from 'reakit/ts';
 
 export type ButtonType = 'default' | 'outlined' | 'link' | 'ghost';
 export const buttonTypePropType = PropTypes.oneOf(['default', 'outlined', 'link', 'ghost']) as PropTypes.Validator<
@@ -129,4 +130,9 @@ export const restrictDefaultProps = {
 export type StyledProps = {
   theme: {};
   tone?: number;
+};
+
+export type ReakitBoxProps = BoxProps & {
+  hiddenBreakpoint?: Breakpoint;
+  showBreakpoint?: Breakpoint;
 };


### PR DESCRIPTION
This is a fix for projects using typescript. The hiddenBreakpoint and showBreakpoint does not exist on the type for components.