### PR TITLE
feat: update react media

### DIFF
--- a/packages/fannypack/package.json
+++ b/packages/fannypack/package.json
@@ -35,7 +35,7 @@
     "prop-types": "15.7.2",
     "react-input-mask": "2.0.4",
     "react-loads-next": "9.0.1",
-    "react-media": "1.9.2",
+    "react-media": "1.10.0",
     "react-remarkable": "1.1.3",
     "react-syntax-highlighter": "8.0.1",
     "reakit": "0.16.0",


### PR DESCRIPTION
Updates react-media to 1.10.0

### Why
The previous version uses ```componentWillMount```, which was fixed in 1.10.0 according to this comment https://github.com/ReactTraining/react-media/issues/134#issuecomment-520776934