### PR TITLE
Fix/a11y on toast component

### DIFF
--- a/packages/fannypack/src/Toast/Toast.tsx
+++ b/packages/fannypack/src/Toast/Toast.tsx
@@ -45,7 +45,7 @@ export const Toast: React.FunctionComponent<LocalToastProps> & ToastComponents =
   type,
   ...props
 }) => (
-  <_Toast type={type} {...props}>
+  <_Toast role="alert" type={type} {...props}>
     {showCountdownBar && (
       <React.Fragment>
         <CountdownBar isHorizontal={hasHorizontalBar} type={type} isBackground />

--- a/packages/fannypack/src/Toast/ToastIcon.tsx
+++ b/packages/fannypack/src/Toast/ToastIcon.tsx
@@ -17,7 +17,7 @@ export const ToastIcon: React.FunctionComponent<LocalToastIconProps> = ({ size, 
   <ToastIconWrapper {...props}>
     {/*
       // @ts-ignore */}
-    <_ToastIcon a11yLabel={type} color={type} icon={type} size={size} />
+    <_ToastIcon aria-hidden a11yLabel={type} color={type} icon={type} size={size} />
   </ToastIconWrapper>
 );
 


### PR DESCRIPTION
Toast Fixes:
✅  added aria-hidden on ToastIcon
✅  added role="alert" on `<_Toast` 

Now Mac VoiceOver screen-reader omits the icon:
![toast-a11-y](https://user-images.githubusercontent.com/41710405/76820515-858ccb00-685f-11ea-8555-0e3d8c373866.gif)

How to review:

- run `yarn docs`
- CMD+F5 to turn on VoiceOver on OS X
- navigate with `TAB` to focus the "Add toast" button control.
- Press the `Enter` key.
- you should be able to hear the Toast elements: Heading, Message and Close button (see screenshot above)
 
