### PR TITLE
Fix/A11Y Fannypack/Checkbox

### DIFF
--- a/packages/fannypack/src/Checkbox/Checkbox.tsx
+++ b/packages/fannypack/src/Checkbox/Checkbox.tsx
@@ -58,13 +58,7 @@ export const Checkbox: React.FunctionComponent<LocalCheckboxProps> & CheckboxCom
   value,
   ...props
 }) => (
-  <_Checkbox
-    aria-describedby="label"
-    aria-invalid={state === 'danger'}
-    aria-label={label}
-    aria-required={isRequired}
-    {...props}
-  >
+  <_Checkbox aria-invalid={state === 'danger'} aria-required={isRequired} {...props}>
     <HiddenCheckbox
       autoFocus={autoFocus}
       checked={checked}
@@ -82,11 +76,7 @@ export const Checkbox: React.FunctionComponent<LocalCheckboxProps> & CheckboxCom
       value={value}
     />
     <CheckboxIcon state={state} />
-    {label && (
-      <Text id="label" htmlFor={id} marginLeft="minor-2">
-        {label}
-      </Text>
-    )}
+    {label && <Text marginLeft="minor-2">{label}</Text>}
   </_Checkbox>
 );
 

--- a/packages/fannypack/src/Checkbox/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/fannypack/src/Checkbox/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -193,9 +193,7 @@ samp.c7 {
 }
 
 <label
-  aria-describedby="label"
   aria-invalid="false"
-  aria-label="Hello"
   aria-required="false"
   class="c0 c1 c2"
 >
@@ -209,7 +207,6 @@ samp.c7 {
   />
   <span
     class="c7 c8"
-    id="label"
   >
     Hello
   </span>
@@ -409,9 +406,7 @@ samp.c7 {
 }
 
 <label
-  aria-describedby="label"
   aria-invalid="false"
-  aria-label="Hello"
   aria-required="false"
   class="c0 c1 c2"
 >
@@ -426,7 +421,6 @@ samp.c7 {
   />
   <span
     class="c7 c8"
-    id="label"
   >
     Hello
   </span>
@@ -665,9 +659,7 @@ samp.c7 {
 }
 
 <label
-  aria-describedby="label"
   aria-invalid="false"
-  aria-label="Hello"
   aria-required="false"
   class="c0 c1 c2"
 >
@@ -682,7 +674,6 @@ samp.c7 {
   />
   <span
     class="c7 c8"
-    id="label"
   >
     Hello
   </span>
@@ -972,9 +963,7 @@ samp.c7 {
 }
 
 <label
-  aria-describedby="label"
   aria-invalid="true"
-  aria-label="Hello"
   aria-required="false"
   class="c0 c1 c2"
 >
@@ -988,7 +977,6 @@ samp.c7 {
   />
   <span
     class="c7 c8"
-    id="label"
   >
     Hello
   </span>
@@ -1278,9 +1266,7 @@ samp.c7 {
 }
 
 <label
-  aria-describedby="label"
   aria-invalid="false"
-  aria-label="Hello"
   aria-required="false"
   class="c0 c1 c2"
 >
@@ -1294,7 +1280,6 @@ samp.c7 {
   />
   <span
     class="c7 c8"
-    id="label"
   >
     Hello
   </span>
@@ -1584,9 +1569,7 @@ samp.c7 {
 }
 
 <label
-  aria-describedby="label"
   aria-invalid="false"
-  aria-label="Hello"
   aria-required="false"
   class="c0 c1 c2"
 >
@@ -1600,7 +1583,6 @@ samp.c7 {
   />
   <span
     class="c7 c8"
-    id="label"
   >
     Hello
   </span>
@@ -1890,9 +1872,7 @@ samp.c7 {
 }
 
 <label
-  aria-describedby="label"
   aria-invalid="false"
-  aria-label="Hello"
   aria-required="false"
   class="c0 c1 c2"
 >
@@ -1906,7 +1886,6 @@ samp.c7 {
   />
   <span
     class="c7 c8"
-    id="label"
   >
     Hello
   </span>

--- a/packages/fannypack/src/Checkbox/__tests__/__snapshots__/CheckboxField.test.tsx.snap
+++ b/packages/fannypack/src/Checkbox/__tests__/__snapshots__/CheckboxField.test.tsx.snap
@@ -196,9 +196,7 @@ samp.c7 {
   class="c0"
 >
   <label
-    aria-describedby="label"
     aria-invalid="false"
-    aria-label="Check me"
     aria-required="false"
     class="c1 c2 c0"
   >
@@ -212,7 +210,6 @@ samp.c7 {
     />
     <span
       class="c7 c8"
-      id="label"
     >
       Check me
     </span>
@@ -417,9 +414,7 @@ samp.c7 {
   class="c0"
 >
   <label
-    aria-describedby="label"
     aria-invalid="false"
-    aria-label="Check me"
     aria-required="false"
     class="c1 c2 c0"
   >
@@ -434,7 +429,6 @@ samp.c7 {
     />
     <span
       class="c7 c8"
-      id="label"
     >
       Check me
     </span>
@@ -749,9 +743,7 @@ samp.c7 {
     <div />
   </div>
   <label
-    aria-describedby="label"
     aria-invalid="false"
-    aria-label="Check me"
     aria-required="true"
     class="c8 c5 c0"
   >
@@ -765,7 +757,6 @@ samp.c7 {
     />
     <span
       class="c7 c13"
-      id="label"
     >
       Check me
     </span>
@@ -1077,9 +1068,7 @@ samp.c7 {
     </span>
   </div>
   <label
-    aria-describedby="label"
     aria-invalid="false"
-    aria-label="Check me"
     aria-required="false"
     class="c8 c5 c0"
   >
@@ -1093,7 +1082,6 @@ samp.c7 {
     />
     <span
       class="c7 c13"
-      id="label"
     >
       Check me
     </span>
@@ -1402,9 +1390,7 @@ samp.c11 {
     <div />
   </div>
   <label
-    aria-describedby="label"
     aria-invalid="false"
-    aria-label="Check me"
     aria-required="false"
     class="c6 c5 c0"
   >
@@ -1418,7 +1404,6 @@ samp.c11 {
     />
     <span
       class="c11 c12"
-      id="label"
     >
       Check me
     </span>
@@ -1737,9 +1722,7 @@ samp.c7 {
     <div />
   </div>
   <label
-    aria-describedby="label"
     aria-invalid="false"
-    aria-label="Check me"
     aria-required="false"
     class="c8 c5 c0"
   >
@@ -1753,7 +1736,6 @@ samp.c7 {
     />
     <span
       class="c7 c13"
-      id="label"
     >
       Check me
     </span>
@@ -2009,9 +1991,7 @@ samp.c7 {
   class="c0"
 >
   <label
-    aria-describedby="label"
     aria-invalid="true"
-    aria-label="Check me"
     aria-required="false"
     class="c1 c2 c0"
   >
@@ -2025,7 +2005,6 @@ samp.c7 {
     />
     <span
       class="c7 c8"
-      id="label"
     >
       Check me
     </span>
@@ -2281,9 +2260,7 @@ samp.c7 {
   class="c0"
 >
   <label
-    aria-describedby="label"
     aria-invalid="false"
-    aria-label="Check me"
     aria-required="false"
     class="c1 c2 c0"
   >
@@ -2297,7 +2274,6 @@ samp.c7 {
     />
     <span
       class="c7 c8"
-      id="label"
     >
       Check me
     </span>
@@ -2553,9 +2529,7 @@ samp.c7 {
   class="c0"
 >
   <label
-    aria-describedby="label"
     aria-invalid="false"
-    aria-label="Check me"
     aria-required="false"
     class="c1 c2 c0"
   >
@@ -2569,7 +2543,6 @@ samp.c7 {
     />
     <span
       class="c7 c8"
-      id="label"
     >
       Check me
     </span>
@@ -2825,9 +2798,7 @@ samp.c7 {
   class="c0"
 >
   <label
-    aria-describedby="label"
     aria-invalid="false"
-    aria-label="Check me"
     aria-required="false"
     class="c1 c2 c0"
   >
@@ -2841,7 +2812,6 @@ samp.c7 {
     />
     <span
       class="c7 c8"
-      id="label"
     >
       Check me
     </span>


### PR DESCRIPTION
## Problem:

Currently, if I want to use screen Reader to navigate the checkbox, Its Label "Receive newsletter" is not being read as expected on a usual native Checkbox implementation.
 
Current Fannypack/Checkbox `Unchecked` state:
<img width="705" alt="Screen Shot 2020-03-17 at 4 55 52 pm" src="https://user-images.githubusercontent.com/41710405/76826296-3a2ee880-6870-11ea-90d9-a6bd915aadfd.png">

Current Fannypack/Checkbox `Checked` state:
<img width="541" alt="Screen Shot 2020-03-17 at 4 55 58 pm" src="https://user-images.githubusercontent.com/41710405/76826289-38652500-6870-11ea-8020-d4c27586012e.png">

Example via https://codesandbox.io/s/a11y-example-1-checkboxes-9h49e


## Some Context on Semantic Checkboxes:
- There are two ways of making a Checkbox accessible just by using native HTML element and structure:

#### Example 1 where `<label>` is wrapping  the input and text:
```
 <label>
          <input type="checkbox" id="newsletter" />
          Receive Newsletter 
 </label>
```

#### Example 2 where `htmlFor` associates the input with the label:
```
 <input type="checkbox" id="newsletter" />
 <label htmlFor="newsletter">Receive Newsletter</label>
 ```

The issue seems like the  `Fannypack/Checkbox` is mixing both techniques, and also adding unnecessary `aria-label`. We can sort out the Accessibility following one of the two examples described above, and keep `aria-label` for other custom widgets, such as accordions and custom-made buttons.


## My suggested solution:
In order to follow example 1 approach (label wrapping input and text) I have made a few changes in the Checkbox component. so the result can be test on the screenshot below,  where the screen Reader now is able to describe the Label text AND State on the focused checkbox.

### Initial State:
<img width="772" alt="Screen Shot 2020-03-17 at 4 38 54 pm" src="https://user-images.githubusercontent.com/41710405/76829056-69485880-6876-11ea-91b2-fd2a68f0f774.png">

### Checked:
<img width="804" alt="Screen Shot 2020-03-17 at 4 39 02 pm" src="https://user-images.githubusercontent.com/41710405/76825437-14a0df80-686e-11ea-8b96-052bbbaa1060.png">

### Unchecked:

<img width="768" alt="Screen Shot 2020-03-17 at 4 39 05 pm" src="https://user-images.githubusercontent.com/41710405/76829118-85e49080-6876-11ea-84b2-cd6597ea9cf2.png">

