### PR TITLE
update --scope package parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:fab": "yarn build && lerna run build:fab",
     "clean": "lerna run clean --stream",
     "develop": "lerna run develop --scope=fannypack --stream",
-    "docs": "lerna run start --scope=website --stream",
+    "docs": "lerna run start --scope=fannypack-website --stream",
     "prepare": "lerna run prepare",
     "clean-packages": "lerna clean",
     "publish-packages": "lerna publish",


### PR DESCRIPTION
Currently, running `yarn docs` results in an error:

```lerna ERR! EFILTER No packages remain after filtering [ 'website' ]```

because the name of the package in `packages/website/package.json` is `fannypack-website`, not `website`. 

